### PR TITLE
Security: Update urllib3 to v2.6.3 (CVE fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-03-15
+
+### Security
+- Updated urllib3 from >=2.5.0 to >=2.6.3 to address multiple high-severity vulnerabilities:
+  - CVE-2026-21441: Decompression-bomb safeguards bypassed when following HTTP redirects (streaming API)
+  - CVE-2025-66471: Streaming API improperly handles highly compressed data
+  - CVE-2025-66418: Unbounded number of links in the decompression chain
+
 ## [1.2.3] - 2025-10-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "purl2src"
-version = "1.2.3"
+version = "1.2.4"
 description = "Translate Package URLs (PURLs) into validated download URLs for source code artifacts"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "click>=8.0.0",
     "requests>=2.28.0",
-    "urllib3>=2.5.0",
+    "urllib3>=2.6.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Update urllib3 from >=2.5.0 to >=2.6.3 to address 3 high-severity CVEs
- Bump version to 1.2.4 for security release

## Security Vulnerabilities Addressed
| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-21441 | HIGH | Decompression-bomb safeguards bypassed when following HTTP redirects (streaming API) |
| CVE-2025-66471 | HIGH | Streaming API improperly handles highly compressed data |
| CVE-2025-66418 | HIGH | Unbounded number of links in the decompression chain |

## Impact
This project uses the streaming API (`stream=True` + `iter_content()`) in `src/purl2src/utils/http.py` to download packages from external registries. The vulnerabilities could allow denial of service via decompression bombs from malicious sources.

## Test Plan
- [x] All 314 unit tests pass
- [x] All 12 e2e tests pass (npm, pypi, rubygems, cargo, nuget, maven, golang, github, conda)
- [x] All 3 integration tests pass
- [x] CLI verified working with urllib3 2.6.3